### PR TITLE
Support passing all Upload Dialog options as props

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It supports multi-file uploads, manual crop, integrations with social networks a
 
 ## Docs
 
-See the complete docs on using Uploadcare Widget [here](https://uploadcare.com/documentation/widget/?utm_source=tipe&utm_campaign=tipe-oss).
+See the complete docs on using Uploadcare Widget [here](https://uploadcare.com/documentation/widget/?utm_source=tipe&utm_campaign=tipe-oss).  See the [usage](#usage) section for component props.
 
 ## Types of bundles
 
@@ -82,6 +82,9 @@ Your secret key is not required for the widget
   <button>New Asset</button>
 </uploadcare>
 ```
+
+### Component Props
+Internally, the component uses the [Open Dialog API](https://uploadcare.com/docs/api_reference/javascript/dialog_panel/) and uses the props as options.  All of the options on the [Widget Configuration](https://uploadcare.com/docs/uploads/widget/config/) page are supported as props.
 
 ## Configuration
 

--- a/src/Uploadcare.vue
+++ b/src/Uploadcare.vue
@@ -16,25 +16,130 @@
         type: Boolean,
         default: false
       },
+      multipleMax: {
+        type: Number
+      },
+      multipleMin: {
+        type: Number
+      },
+      imagesOnly: {
+        type: Boolean,
+        default: false
+      },
+      // Default value does not match the UploadCare API default.
+      previewStep: {
+        type: Boolean,
+        default: true
+      },
       crop: {
         type: String,
         default: ''
       },
+      imageShrink: {
+        type: Boolean,
+        default: false
+      },
+      clearable: {
+        type: Boolean,
+        default: false
+      },
       tabs: {
         type: String,
         default: 'file url camera dropbox gdrive box skydrive'
+      },
+      inputAcceptTypes: {
+        type: String
+      },
+      preferredTypes: {
+        type: String
+      },
+      // Default value does not match the UploadCare API default.
+      systemDialog: {
+        type: Boolean,
+        default: true
+      },
+      multipartMinSize: {
+        type: Number,
+        default: 26214400
+      },
+      secureSignature: {
+        type: String
+      },
+      secureExpire: {
+        type: Number
+      },
+      previewProxy: {
+        type: String
+      },
+      previewUrlCallback: {
+        type: Function
+      },
+      cdnBase: {
+        type: String
+      },
+      doNotStore: {
+        type: Boolean,
+        default: false
+      },
+      validators: {
+        type: Array
       }
     },
     methods: {
       onClick () {
-        this.fileGroup = uploadcare.openDialog([], {
-          publicKey: this.publicKey,
-          multiple: this.multiple,
-          crop: this.crop,
-          tabs: this.tabs,
-          systemDialog: true,
-          previewStep: true
-        })
+        const {
+          publicKey,
+          multiple,
+          multipleMax,
+          multipleMin,
+          imagesOnly,
+          previewStep,
+          crop,
+          imageShrink,
+          clearable,
+          tabs,
+          inputAcceptTypes,
+          preferredTypes,
+          systemDialog,
+          multipartMinSize,
+          secureSignature,
+          secureExpire,
+          previewProxy,
+          previewUrlCallback,
+          cdnBase,
+          doNotStore,
+          validators
+        } = this
+
+        const options = {
+          publicKey,
+          multiple,
+          multipleMax,
+          multipleMin,
+          imagesOnly,
+          previewStep,
+          crop,
+          imageShrink,
+          clearable,
+          tabs,
+          inputAcceptTypes,
+          preferredTypes,
+          systemDialog,
+          multipartMinSize,
+          secureSignature,
+          secureExpire,
+          previewProxy,
+          previewUrlCallback,
+          cdnBase,
+          doNotStore,
+          validators
+        }
+
+        if (validators && validators.length) {
+          Object.assign(options, { validators })
+        }
+
+        this.fileGroup = uploadcare.openDialog([], options)
 
         this.fileGroup.done((filePromise) => {
           if (this.multiple) {

--- a/src/Uploadcare.vue
+++ b/src/Uploadcare.vue
@@ -131,8 +131,7 @@
           previewProxy,
           previewUrlCallback,
           cdnBase,
-          doNotStore,
-          validators
+          doNotStore
         }
 
         if (validators && validators.length) {


### PR DESCRIPTION
All of the options on the [Widget Configuration](https://uploadcare.com/docs/uploads/widget/config/) page are supported as props.

This should be a non-breaking change, since I've kept the previous default values for `previewStep` and `systemDialog` as prop defaults.  They're now configurable as props, though. (Though I didn't notice that changing `systemDialog` made any difference in behavior on a Mac)